### PR TITLE
use bioconductor/bioconductor_docker:bioc2020.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bioconductor/bioconductor_docker:bioc2020
+FROM bioconductor/bioconductor_docker:bioc2020.1
 
 WORKDIR /home/rstudio
 
@@ -6,6 +6,6 @@ COPY --chown=rstudio:rstudio . /home/rstudio/
 
 ENV R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
 
-RUN Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); BiocManager::install(ask=FALSE, Ncpus=2)"
+RUN Rscript -e "BiocManager::install(ask=FALSE, Ncpus=2)"
 
-RUN Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); devtools::install('.', dependencies=TRUE, build_vignettes=TRUE, repos = BiocManager::repositories(), Ncpus=2)"
+RUN Rscript -e "devtools::install('.', dependencies=TRUE, build_vignettes=TRUE, repos = BiocManager::repositories(), Ncpus=2)"


### PR DESCRIPTION
with no need to specify cran mirror